### PR TITLE
fix(invoice): fix date saving bugs in edit mode

### DIFF
--- a/resources/js/pages/NewInvoice.tsx
+++ b/resources/js/pages/NewInvoice.tsx
@@ -139,6 +139,13 @@ const MAX_VISIBLE_ERRORS = 5;
 const ERROR_TOAST_DURATION_MS = 12000;
 const MAX_RECURSION_DEPTH = 10;
 
+const formatDateForApi = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
 const NewInvoice = () => {
   const navigate = useNavigate();
   const { id } = useParams();
@@ -471,6 +478,13 @@ const NewInvoice = () => {
       const issueDateObj = new Date(invoice.issue_date);
       const dueDateObj = new Date(invoice.due_date);
       const deliveryDateObj = new Date(invoice.delivery_date);
+
+      // Calculate dueDateDays from actual data BEFORE setting issueDate
+      // so the useEffect doesn't overwrite dueDate with a recalculated value
+      const diffTime = Math.abs(dueDateObj.getTime() - issueDateObj.getTime());
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+      setDueDateDays(diffDays);
+
       setIssueDate(issueDateObj);
       setDueDate(dueDateObj);
       setDeliveryDate(deliveryDateObj);
@@ -550,9 +564,9 @@ const NewInvoice = () => {
         customCompanyZip: data.customCompanyZip,
         customCompanyCountry: data.customCompanyCountry,
         invoiceNumber: data.invoiceNumber,
-        issue_date: data.issueDate.toISOString().split('T')[0], // Format: YYYY-MM-DD
-        due_date: data.dueDate.toISOString().split('T')[0], // Format: YYYY-MM-DD
-        delivery_date: data.deliveryDate.toISOString().split('T')[0], // Format: YYYY-MM-DD
+        issue_date: formatDateForApi(data.issueDate),
+        due_date: formatDateForApi(data.dueDate),
+        delivery_date: formatDateForApi(data.deliveryDate),
         variableSymbol: data.variableSymbol,
         constantSymbol: data.constantSymbol,
         specificSymbol: data.specificSymbol,


### PR DESCRIPTION
## Summary
- **Timezone fix**: `toISOString()` converted local midnight (CET) to UTC, shifting dates back by 1 day. Replaced with `formatDateForApi()` that uses local time getters (`getFullYear`, `getMonth`, `getDate`).
- **Due date overwrite on edit load**: `useEffect` recalculated `dueDate` as `issueDate + 15` (default) when loading invoice data. Now calculates actual `dueDateDays` from the invoice before setting `issueDate`, so the effect preserves the correct value.

## Test plan
- [ ] Open an existing invoice for editing — verify dates loaded correctly (not recalculated to +15 days)
- [ ] Change due date and delivery date manually, save
- [ ] Reopen the invoice — verify dates match exactly what was selected (no 1-day shift)
- [ ] Create a new invoice — verify default date behavior still works (due date = issue date + 15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of due date calculations when loading and editing invoices to ensure the days between issue and due dates are accurately preserved and not overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->